### PR TITLE
Add Nixpacks start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ Set the `BOT_TOKEN` environment variable with your bot token and run:
 ```bash
 python bot.py
 ```
+
+For Railway or Nixpacks deployments, set the start command to `python bot.py` in `nixpacks.toml` or a `Procfile`.

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,2 @@
+[start]
+cmd = "python bot.py"


### PR DESCRIPTION
## Summary
- add `nixpacks.toml` with `python bot.py`
- document start command in README for Railway/Nixpacks

## Testing
- `python bot.py` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_686c2c867e88832082592f8d5871de0a