### PR TITLE
Implement temporary message deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,6 @@ python bot.py
 ```
 
 For Railway or Nixpacks deployments, set the start command to `python bot.py` in `nixpacks.toml` or a `Procfile`.
+
+Messages sent via some commands are automatically deleted. You can configure the
+delay using the `DELETE_DELAY` environment variable (in seconds, default `30`).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 aiogram>=3.0
+pytest
+pytest-asyncio

--- a/tests/test_auto_delete.py
+++ b/tests/test_auto_delete.py
@@ -1,0 +1,34 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("BOT_TOKEN", "123456789:TESTTOKENEXAMPLEEXAMPLEEXAMPLEEX")
+
+from bot import send_temporary
+
+@pytest.mark.asyncio
+async def test_send_temporary_deletes_message():
+    bot = AsyncMock()
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=10))
+
+    tasks = []
+    orig_create_task = asyncio.create_task
+
+    def fake_create_task(coro):
+        task = orig_create_task(coro)
+        tasks.append(task)
+        return task
+
+    with patch('bot.asyncio.create_task', side_effect=fake_create_task), \
+         patch('bot.asyncio.sleep', new=AsyncMock()) as sleep_mock:
+        await send_temporary(bot, 123, 'hi', delay=5)
+        await asyncio.gather(*tasks)
+        bot.send_message.assert_awaited_with(123, 'hi')
+        assert any(c.args[0] == 5 for c in sleep_mock.await_args_list)
+        bot.delete_message.assert_awaited_with(123, 10)


### PR DESCRIPTION
## Summary
- allow scheduling message deletion with `send_temporary`
- use temporary messages in several handlers
- document `DELETE_DELAY` in the README
- add tests for `send_temporary`
- include testing tools in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c472884408320a4f35a3109f47b38