### PR TITLE
Add Outline VPN integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ For Railway or Nixpacks deployments, set the start command to `python bot.py` in
 
 Messages sent via some commands are automatically deleted. You can configure the
 delay using the `DELETE_DELAY` environment variable (in seconds, default `30`).
+
+If you have an [Outline](https://getoutline.org/) VPN server, set the
+`OUTLINE_API_URL` environment variable to your server's API URL. The bot will
+create a new access key when you select "🔑 Мои активные ключи".

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiogram>=3.0
 pytest
 pytest-asyncio
+outline-api

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -1,0 +1,23 @@
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+os.environ.setdefault("BOT_TOKEN", "TEST")
+
+from bot import create_outline_key
+
+@pytest.mark.asyncio
+async def test_create_outline_key_calls_manager():
+    os.environ["OUTLINE_API_URL"] = "https://example.com/api"
+    with patch('bot.OUTLINE_API_URL', "https://example.com/api"), \
+         patch('bot.Manager') as manager_cls:
+        manager = manager_cls.return_value
+        manager.new.return_value = {"accessUrl": "url"}
+        res = await create_outline_key("label")
+        manager_cls.assert_called_with(apiurl="https://example.com/api", apicrt="")
+        manager.new.assert_called_with("label")
+        assert res == {"accessUrl": "url"}


### PR DESCRIPTION
## Summary
- integrate Outline VPN via `outline_api` library
- add helper to create access keys
- show Outline key for "Мои активные ключи" menu item
- document Outline usage in README
- test Outline key creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c4b01ee988320890141e4aa73f864