### PR TITLE
Add SQLite DB for VPN access tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Telegram VPN Bot
 
 Simple Telegram bot using [aiogram](https://docs.aiogram.dev/) v3.
+The bot stores issued VPN keys in a local SQLite database so that each
+user can only obtain a trial VPN once and paid keys expire automatically.
 
 ## Features
 
@@ -26,6 +28,10 @@ Set the `BOT_TOKEN` environment variable with your bot token and run:
 ```bash
 python bot.py
 ```
+
+The bot saves issued keys in a SQLite database. By default the database
+file `vpn.sqlite` is created in the current directory. You can override
+the location using the `DB_PATH` environment variable.
 
 For Railway or Nixpacks deployments, set the start command to `python bot.py` in `nixpacks.toml` or a `Procfile`.
 

--- a/db.py
+++ b/db.py
@@ -1,0 +1,62 @@
+import os
+import sqlite3
+from contextlib import closing
+
+DB_PATH = os.getenv("DB_PATH", "vpn.sqlite")
+
+
+def get_connection():
+    return sqlite3.connect(DB_PATH)
+
+
+def init_db() -> None:
+    with closing(get_connection()) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS vpn_access (
+                user_id INTEGER,
+                is_trial INTEGER,
+                key_id INTEGER,
+                access_url TEXT,
+                expires_at INTEGER,
+                PRIMARY KEY (user_id, is_trial)
+            )
+            """
+        )
+        conn.commit()
+
+
+def add_key(user_id: int, key_id: int, access_url: str, expires_at: int, is_trial: bool) -> None:
+    with closing(get_connection()) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO vpn_access (user_id, is_trial, key_id, access_url, expires_at) VALUES (?, ?, ?, ?, ?)",
+            (user_id, int(is_trial), key_id, access_url, expires_at),
+        )
+        conn.commit()
+
+
+def clear_key(user_id: int, is_trial: bool) -> None:
+    with closing(get_connection()) as conn:
+        conn.execute(
+            "UPDATE vpn_access SET key_id=NULL, access_url=NULL, expires_at=NULL WHERE user_id=? AND is_trial=?",
+            (user_id, int(is_trial)),
+        )
+        conn.commit()
+
+
+def get_active_key(user_id: int):
+    with closing(get_connection()) as conn:
+        row = conn.execute(
+            "SELECT access_url, expires_at, is_trial FROM vpn_access WHERE user_id=? AND key_id IS NOT NULL",
+            (user_id,),
+        ).fetchone()
+        return row
+
+
+def has_used_trial(user_id: int) -> bool:
+    with closing(get_connection()) as conn:
+        row = conn.execute(
+            "SELECT 1 FROM vpn_access WHERE user_id=? AND is_trial=1",
+            (user_id,),
+        ).fetchone()
+        return row is not None

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -42,21 +42,14 @@ async def test_callback_trial_creates_key_and_schedules_deletion():
 
     callback = SimpleNamespace(from_user=SimpleNamespace(id=1), message=message, answer=AsyncMock())
 
-    tasks = []
-    orig_create_task = asyncio.create_task
-
-    def fake_create_task(coro):
-        task = orig_create_task(coro)
-        tasks.append(task)
-        return task
-
     manager = Mock()
     with patch('bot.create_outline_key', AsyncMock(return_value=key)), \
          patch('bot.outline_manager', return_value=manager), \
-         patch('bot.asyncio.create_task', side_effect=fake_create_task), \
-         patch('bot.asyncio.sleep', new=AsyncMock()):
+         patch('bot.add_key') as add_key_mock, \
+         patch('bot.has_used_trial', return_value=False), \
+         patch('bot.schedule_key_deletion', AsyncMock()) as sched_mock:
         await callback_trial(callback)
-        await asyncio.gather(*tasks)
+        add_key_mock.assert_called()
+        sched_mock.assert_awaited_with(key['id'], delay=24 * 60 * 60, user_id=1, is_trial=True)
         message.answer.assert_awaited_with('Ваш пробный ключ на 24 часа:\nurl')
-        manager.delete.assert_called_with(7)
         callback.answer.assert_awaited()


### PR DESCRIPTION
## Summary
- keep track of trial and paid VPN keys in a new SQLite database
- enforce single trial per user and expire keys automatically
- generate paid keys with expiry when selecting a payment method
- show existing key or expiration notice in "Мои активные ключи"
- document new DB usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c516fe2a88320abef58af55cb5a14