### PR TITLE
Update label format for Outline keys

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -134,7 +134,7 @@ async def callback_trial(callback: types.CallbackQuery):
         await send_temporary(bot, callback.message.chat.id, "Вы уже использовали пробный период.")
     else:
         try:
-            key = await create_outline_key(f"trial-{callback.from_user.id}")
+            key = await create_outline_key(label=f"vpn_{callback.from_user.id}")
             expires = int(time.time() + 24 * 60 * 60)
             add_key(callback.from_user.id, key.get("id"), key.get("accessUrl"), expires, True)
             await schedule_key_deletion(key.get("id"), delay=24 * 60 * 60, user_id=callback.from_user.id, is_trial=True)
@@ -249,7 +249,7 @@ async def select_method(message: types.Message, state: FSMContext):
     )
 
     try:
-        key = await create_outline_key(f"paid-{message.from_user.id}")
+        key = await create_outline_key(label=f"vpn_{message.from_user.id}")
         duration = tariff.get("days", 30) * 24 * 60 * 60
         expires = int(time.time() + duration)
         add_key(message.from_user.id, key.get("id"), key.get("accessUrl"), expires, False)

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -17,7 +17,7 @@ async def test_create_outline_key_calls_manager():
          patch('bot.Manager') as manager_cls:
         manager = manager_cls.return_value
         manager.new.return_value = {"accessUrl": "url"}
-        res = await create_outline_key("label")
+        res = await create_outline_key(label="vpn_7")
         manager_cls.assert_called_with(apiurl="https://example.com/api", apicrt="")
-        manager.new.assert_called_with("label")
+        manager.new.assert_called_with("vpn_7")
         assert res == {"accessUrl": "url"}

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -43,12 +43,14 @@ async def test_callback_trial_creates_key_and_schedules_deletion():
     callback = SimpleNamespace(from_user=SimpleNamespace(id=1), message=message, answer=AsyncMock())
 
     manager = Mock()
-    with patch('bot.create_outline_key', AsyncMock(return_value=key)), \
+    create_key_mock = AsyncMock(return_value=key)
+    with patch('bot.create_outline_key', create_key_mock), \
          patch('bot.outline_manager', return_value=manager), \
          patch('bot.add_key') as add_key_mock, \
          patch('bot.has_used_trial', return_value=False), \
          patch('bot.schedule_key_deletion', AsyncMock()) as sched_mock:
         await callback_trial(callback)
+        create_key_mock.assert_awaited_with(label="vpn_1")
         add_key_mock.assert_called()
         sched_mock.assert_awaited_with(key['id'], delay=24 * 60 * 60, user_id=1, is_trial=True)
         message.answer.assert_awaited_with('Ваш пробный ключ на 24 часа:\nurl')


### PR DESCRIPTION
## Summary
- modify VPN key label format to `vpn_<user_id>` in bot logic
- verify label usage in callback trial test
- adjust outline key unit test for label

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd45625548320a0aaf270cb7f3e38