### PR TITLE
Add bot token validation and test

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -21,6 +21,9 @@ TOKEN = os.getenv("BOT_TOKEN")
 
 logging.basicConfig(level=logging.INFO)
 
+if not TOKEN:
+    raise RuntimeError("BOT_TOKEN not configured")
+
 bot = Bot(token=TOKEN)
 dp = Dispatcher()
 

--- a/tests/test_bot_token.py
+++ b/tests/test_bot_token.py
@@ -1,0 +1,16 @@
+import importlib
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def test_missing_token_raises_error(monkeypatch):
+    monkeypatch.delenv("BOT_TOKEN", raising=False)
+    orig_mod = sys.modules.pop("bot", None)
+    with pytest.raises(RuntimeError, match="BOT_TOKEN not configured"):
+        importlib.import_module("bot")
+    if orig_mod is not None:
+        sys.modules["bot"] = orig_mod


### PR DESCRIPTION
## Summary
- ensure `BOT_TOKEN` is set before creating the `Bot`
- test that missing token triggers a runtime error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd52fc5b483209c4e4a61a00c6fe1