### PR TITLE
Switch to async SQLite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ aiogram>=3.0
 pytest
 pytest-asyncio
 outline-api
+aiosqlite

--- a/tests/test_db_async.py
+++ b/tests/test_db_async.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import asyncio
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from db import init_db, add_key, get_active_key, clear_key, has_used_trial
+
+
+@pytest.mark.asyncio
+async def test_add_and_get_key(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.sqlite"
+    monkeypatch.setenv("DB_PATH", str(db_file))
+    await init_db()
+    await add_key(1, 2, "url", 123, False)
+    row = await get_active_key(1)
+    assert row == ("url", 123, 0)
+
+
+@pytest.mark.asyncio
+async def test_has_used_trial(tmp_path, monkeypatch):
+    db_file = tmp_path / "trial.sqlite"
+    monkeypatch.setenv("DB_PATH", str(db_file))
+    await init_db()
+    assert not await has_used_trial(1)
+    await add_key(1, 2, "url", 123, True)
+    assert await has_used_trial(1)
+    await clear_key(1, True)
+    # even after clearing, trial usage remains recorded
+    assert await has_used_trial(1)

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -48,14 +48,14 @@ async def test_callback_trial_creates_key_and_schedules_deletion():
     create_key_mock = AsyncMock(return_value=key)
     with patch("bot.create_outline_key", create_key_mock), patch(
         "bot.outline_manager", return_value=manager
-    ), patch("bot.add_key") as add_key_mock, patch(
-        "bot.has_used_trial", return_value=False
+    ), patch("bot.add_key", new=AsyncMock()) as add_key_mock, patch(
+        "bot.has_used_trial", new=AsyncMock(return_value=False)
     ), patch(
         "bot.schedule_key_deletion", AsyncMock()
     ) as sched_mock:
         await callback_trial(callback)
         create_key_mock.assert_awaited_with(label="vpn_1")
-        add_key_mock.assert_called()
+        add_key_mock.assert_awaited()
         sched_mock.assert_awaited_with(
             key["id"], delay=24 * 60 * 60, user_id=1, is_trial=True
         )


### PR DESCRIPTION
## Summary
- use `aiosqlite` in `db.py` and expose async DB helpers
- await DB helpers throughout `bot.py`
- update requirements
- fix tests for new async functions
- add new async DB tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d19a308a48320b4e1bb3d08a2e1bc