### PR TITLE
Improve tests with shared fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Shared pytest fixtures for tests."""
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture
+def task_spy():
+    """Return a task list and a replacement for ``asyncio.create_task``."""
+    tasks = []
+    orig_create_task = asyncio.create_task
+
+    def fake_create_task(coro):
+        task = orig_create_task(coro)
+        tasks.append(task)
+        return task
+
+    return tasks, fake_create_task

--- a/tests/test_auto_delete.py
+++ b/tests/test_auto_delete.py
@@ -1,7 +1,8 @@
-import os
-import sys
+"""Tests for ``send_temporary`` message auto-deletion."""
 
 import asyncio
+import os
+import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -16,17 +17,11 @@ from bot import send_temporary  # noqa: E402
 
 
 @pytest.mark.asyncio
-async def test_send_temporary_deletes_message():
+async def test_send_temporary_deletes_message(task_spy):
     bot = AsyncMock()
     bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=10))
 
-    tasks = []
-    orig_create_task = asyncio.create_task
-
-    def fake_create_task(coro):
-        task = orig_create_task(coro)
-        tasks.append(task)
-        return task
+    tasks, fake_create_task = task_spy
 
     with patch("bot.asyncio.create_task", side_effect=fake_create_task), patch(
         "bot.asyncio.sleep", new=AsyncMock()

--- a/tests/test_bot_token.py
+++ b/tests/test_bot_token.py
@@ -1,10 +1,12 @@
+"""Tests that missing ``BOT_TOKEN`` raises an error on import."""
+
 import importlib
 import os
 import sys
 
 import pytest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
 
 
 def test_missing_token_raises_error(monkeypatch):

--- a/tests/test_db_async.py
+++ b/tests/test_db_async.py
@@ -1,18 +1,21 @@
+"""Tests for asynchronous database functions."""
+
+import asyncio
 import os
 import sys
-import asyncio
 
 import pytest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
 
-from db import init_db, add_key, get_active_key, clear_key, has_used_trial
+from db import add_key, clear_key, get_active_key, has_used_trial, init_db  # noqa: E402
 
 
 @pytest.mark.asyncio
 async def test_add_and_get_key(tmp_path, monkeypatch):
     db_file = tmp_path / "test.sqlite"
     monkeypatch.setenv("DB_PATH", str(db_file))
+    monkeypatch.setattr("db.DB_PATH", str(db_file), raising=False)
     await init_db()
     await add_key(1, 2, "url", 123, False)
     row = await get_active_key(1)
@@ -23,6 +26,7 @@ async def test_add_and_get_key(tmp_path, monkeypatch):
 async def test_has_used_trial(tmp_path, monkeypatch):
     db_file = tmp_path / "trial.sqlite"
     monkeypatch.setenv("DB_PATH", str(db_file))
+    monkeypatch.setattr("db.DB_PATH", str(db_file), raising=False)
     await init_db()
     assert not await has_used_trial(1)
     await add_key(1, 2, "url", 123, True)

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -1,6 +1,9 @@
+"""Tests for Outline manager integration."""
+
 import os
 import sys
 from unittest.mock import patch
+
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -1,27 +1,22 @@
-import os
-import sys
+"""Tests for trial key workflow and scheduled deletion."""
 
 import asyncio
+import os
+import sys
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
 os.environ.setdefault("BOT_TOKEN", "TEST")
 
-from bot import schedule_key_deletion, callback_trial  # noqa: E402
+from bot import callback_trial, schedule_key_deletion  # noqa: E402
 
 
 @pytest.mark.asyncio
-async def test_schedule_key_deletion_removes_key():
-    tasks = []
-    orig_create_task = asyncio.create_task
-
-    def fake_create_task(coro):
-        task = orig_create_task(coro)
-        tasks.append(task)
-        return task
+async def test_schedule_key_deletion_removes_key(task_spy):
+    tasks, fake_create_task = task_spy
 
     manager = Mock()
     with patch("bot.outline_manager", return_value=manager), patch(


### PR DESCRIPTION
## Summary
- add module docstrings for clarity across tests
- consolidate fake_create_task logic into `task_spy` fixture
- fix DB path handling in async DB tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1cde9b7083208e72f6f6ee11941c