### PR TITLE
Fix flake8 warnings in tests

### DIFF
--- a/tests/test_db_async.py
+++ b/tests/test_db_async.py
@@ -1,6 +1,5 @@
 """Tests for asynchronous database functions."""
 
-import asyncio
 import os
 import sys
 
@@ -8,7 +7,13 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
 
-from db import add_key, clear_key, get_active_key, has_used_trial, init_db  # noqa: E402
+from db import (  # noqa: E402
+    add_key,
+    clear_key,
+    get_active_key,
+    has_used_trial,
+    init_db,
+)
 
 
 @pytest.mark.asyncio

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -22,7 +22,7 @@ async def test_schedule_key_deletion_removes_key(task_spy):
     with patch("bot.outline_manager", return_value=manager), patch(
         "bot.asyncio.create_task", side_effect=fake_create_task
     ), patch("bot.asyncio.sleep", new=AsyncMock()) as sleep_mock:
-        task = schedule_key_deletion(5, delay=5)
+        _ = schedule_key_deletion(5, delay=5)
         await asyncio.gather(*tasks)
         assert any(c.args[0] == 5 for c in sleep_mock.await_args_list)
         manager.delete.assert_called_with(5)


### PR DESCRIPTION
## Summary
- remove unused `asyncio` import
- split long import line in async DB tests
- discard unused variable when scheduling key deletion
- run flake8

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_686d23b097b08320b5149f0c2085259b