### PR TITLE
Implement referral bonus

### DIFF
--- a/db.py
+++ b/db.py
@@ -94,3 +94,23 @@ async def record_referral(user_id: int, referrer_id: int) -> bool:
             return True
         except aiosqlite.IntegrityError:
             return False
+async def get_key_info(user_id: int):
+    """Return key_id, access_url, expires_at, is_trial for the user if any."""
+    async with get_connection() as conn:
+        cursor = await conn.execute(
+            "SELECT key_id, access_url, expires_at, is_trial FROM vpn_access "
+            "WHERE user_id=? AND key_id IS NOT NULL",
+            (user_id,),
+        )
+        row = await cursor.fetchone()
+        return row
+
+
+async def update_expiration(user_id: int, is_trial: bool, expires_at: int) -> None:
+    """Update the expiration time for the user's key."""
+    async with get_connection() as conn:
+        await conn.execute(
+            "UPDATE vpn_access SET expires_at=? WHERE user_id=? AND is_trial=?",
+            (expires_at, user_id, int(is_trial)),
+        )
+        await conn.commit()

--- a/tests/test_referral.py
+++ b/tests/test_referral.py
@@ -8,7 +8,13 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
 os.environ.setdefault("BOT_TOKEN", "TEST")
 
-from bot import cmd_start, menu_invite  # noqa: E402
+from bot import (
+    cmd_start,
+    menu_invite,
+    grant_referral_bonus,
+    REFERRAL_BONUS_DAYS,
+)
+
 
 
 @pytest.mark.asyncio
@@ -21,10 +27,11 @@ async def test_cmd_start_records_referral():
     )
 
     with patch("bot.record_referral", new=AsyncMock(return_value=True)) as rec, \
-        patch("bot.logging.info") as log:
+        patch("bot.logging.info") as log, patch("bot.grant_referral_bonus", new=AsyncMock()) as bonus:
         await cmd_start(message)
         rec.assert_awaited_with(5, 3)
         log.assert_called_with("User %s joined via referral from %s", 5, 3)
+        bonus.assert_awaited_with(3)
 
 
 @pytest.mark.asyncio
@@ -43,3 +50,38 @@ async def test_menu_invite_generates_link():
     kb = kwargs["reply_markup"]
     assert kb.inline_keyboard[0][0].switch_inline_query == "https://t.me/VPNos_bot?start=ref4"
     assert kb.inline_keyboard[1][0].callback_data == "main_menu"
+
+
+@pytest.mark.asyncio
+async def test_grant_referral_bonus_creates_key():
+    with patch("bot.get_key_info", new=AsyncMock(return_value=None)), patch(
+        "bot.create_outline_key", new=AsyncMock(return_value={"id": 8, "accessUrl": "url"})
+    ) as create_mock, patch(
+        "bot.add_key", new=AsyncMock()
+    ) as add_key_mock, patch(
+        "bot.schedule_key_deletion"
+    ) as sched_mock, patch(
+        "bot.bot.send_message", new=AsyncMock()) as send_mock:
+        await grant_referral_bonus(4)
+        create_mock.assert_awaited_with(label="vpn_4")
+        add_key_mock.assert_awaited()
+        sched_mock.assert_called_with(8, delay=REFERRAL_BONUS_DAYS * 24 * 60 * 60, user_id=4, is_trial=False)
+        send_mock.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_grant_referral_bonus_extends_key():
+    now = 100
+    record = (11, "url", 200, 0)
+    with patch("bot.get_key_info", new=AsyncMock(return_value=record)), patch(
+        "bot.update_expiration", new=AsyncMock()
+    ) as upd_mock, patch(
+        "bot.schedule_key_deletion"
+    ) as sched_mock, patch(
+        "bot.bot.send_message", new=AsyncMock()) as send_mock, patch(
+        "bot.time.time", return_value=now):
+        await grant_referral_bonus(5)
+        new_exp = 200 + REFERRAL_BONUS_DAYS * 24 * 60 * 60
+        upd_mock.assert_awaited_with(5, False, new_exp)
+        sched_mock.assert_called_with(11, delay=new_exp - now, user_id=5, is_trial=False)
+        send_mock.assert_awaited()


### PR DESCRIPTION
## Summary
- grant 3 days of VPN to referrer automatically
- track scheduled deletion tasks so we can reschedule them
- update invite text to mention 3 day bonus
- test referral bonus logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fa084884c8320a939c8c39fecbfa0