### PR TITLE
Fix share link to omit bot mention

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,6 +10,7 @@ from aiogram.types import (
     KeyboardButton,
     ReplyKeyboardMarkup,
 )
+from urllib.parse import quote_plus
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram import F
@@ -474,9 +475,13 @@ async def menu_invite(message: types.Message):
         "Вот твоя реферальная ссылка \U0001f60a:\n"
         f"{link}"
     )
+    share_url = (
+        "https://t.me/share/url?url="
+        f"{quote_plus(link)}&text={quote_plus(link)}"
+    )
     inline_kb = InlineKeyboardMarkup(
         inline_keyboard=[
-            [InlineKeyboardButton(text="\U0001f4e3 Поделиться", switch_inline_query=link)],
+            [InlineKeyboardButton(text="\U0001f4e3 Поделиться", url=share_url)],
             [InlineKeyboardButton(text="\U0001f4a0 Главное меню", callback_data="main_menu")],
         ]
     )

--- a/tests/test_referral.py
+++ b/tests/test_referral.py
@@ -48,7 +48,9 @@ async def test_menu_invite_generates_link():
     args, kwargs = message.answer.call_args
     assert "https://t.me/VPNos_bot?start=ref4" in args[0]
     kb = kwargs["reply_markup"]
-    assert kb.inline_keyboard[0][0].switch_inline_query == "https://t.me/VPNos_bot?start=ref4"
+    button_url = kb.inline_keyboard[0][0].url
+    assert button_url.startswith("https://t.me/share/url")
+    assert "url=https%3A%2F%2Ft.me%2FVPNos_bot%3Fstart%3Dref4" in button_url
     assert kb.inline_keyboard[1][0].callback_data == "main_menu"
 
 


### PR DESCRIPTION
## Summary
- when sharing the referral link, use the Telegram share URL so that only the link is sent
- update referral tests for new button behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc513a9a48320b1b7bc14db2c4c91