### PR TITLE
Add restart buy handler

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -364,6 +364,13 @@ async def menu_buy(message: types.Message, state: FSMContext):
     await state.set_state(BuyVPN.waiting_tariff)
 
 
+@dp.message(BuyVPN.waiting_tariff, F.text == "\U0001f6d2 Купить VPN | \U0001f4c5 Продлить")
+@dp.message(BuyVPN.waiting_method, F.text == "\U0001f6d2 Купить VPN | \U0001f4c5 Продлить")
+async def restart_buy(message: types.Message, state: FSMContext):
+    await state.clear()
+    await menu_buy(message, state)
+
+
 @dp.message(BuyVPN.waiting_tariff, F.text.in_(TARIFFS.keys()))
 async def select_tariff(message: types.Message, state: FSMContext):
     info = TARIFFS.get(message.text)

--- a/tests/test_buy_restart.py
+++ b/tests/test_buy_restart.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("BOT_TOKEN", "TEST")
+
+import bot
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state_name", ["waiting_tariff", "waiting_method"])
+async def test_restart_buy_calls_menu_buy(state_name):
+    message = SimpleNamespace(text="\U0001f6d2 Купить VPN | \U0001f4c5 Продлить")
+    state = SimpleNamespace(clear=AsyncMock())
+    with patch("bot.menu_buy", new=AsyncMock()) as menu_mock:
+        await bot.restart_buy(message, state)
+        state.clear.assert_awaited()
+        menu_mock.assert_awaited_with(message, state)


### PR DESCRIPTION
## Summary
- handle users sending the buy command again while in the buy FSM
- test restart behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870d319a44883209ffc908d112545a4