### PR TITLE
Prevent referrals from existing VPN users

### DIFF
--- a/db.py
+++ b/db.py
@@ -80,9 +80,22 @@ async def has_used_trial(user_id: int) -> bool:
         return row is not None
 
 
+async def has_vpn_history(user_id: int) -> bool:
+    """Return True if the user ever had VPN access."""
+    async with get_connection() as conn:
+        cursor = await conn.execute(
+            "SELECT 1 FROM vpn_access WHERE user_id=?",
+            (user_id,),
+        )
+        row = await cursor.fetchone()
+        return row is not None
+
+
 async def record_referral(user_id: int, referrer_id: int) -> bool:
     """Save referrer relationship. Return ``True`` if stored."""
     if user_id == referrer_id:
+        return False
+    if await has_vpn_history(user_id):
         return False
     async with get_connection() as conn:
         try:

--- a/tests/test_db_async.py
+++ b/tests/test_db_async.py
@@ -48,3 +48,13 @@ async def test_record_referral(tmp_path, monkeypatch):
     assert await record_referral(2, 1)
     assert not await record_referral(2, 1)
     assert not await record_referral(1, 1)
+
+
+@pytest.mark.asyncio
+async def test_record_referral_existing_user(tmp_path, monkeypatch):
+    db_file = tmp_path / "ref.sqlite"
+    monkeypatch.setenv("DB_PATH", str(db_file))
+    monkeypatch.setattr("db.DB_PATH", str(db_file), raising=False)
+    await init_db()
+    await add_key(3, 7, "url", 999, False)
+    assert not await record_referral(3, 1)


### PR DESCRIPTION
## Summary
- track whether any VPN access has been issued to a user
- block new referral links if the invited user already had VPN access
- test that `record_referral` rejects existing users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68710351ae0083208b01ee71776d9e27