### PR TITLE
Show key expiration date

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -329,7 +329,8 @@ async def menu_keys(message: types.Message):
             await clear_key(message.from_user.id, bool(is_trial))
             text = "Срок действия вашего ключа истёк."
         else:
-            text = f"Ваш Outline ключ:\n{access_url}"
+            date_str = time.strftime("%d.%m.%Y", time.localtime(expires_at))
+            text = f"Ваш ключ активен до {date_str}\n{access_url}"
     else:
         text = "У вас нет активного ключа."
     await send_temporary(bot, message.chat.id, text)

--- a/tests/test_menu_keys.py
+++ b/tests/test_menu_keys.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+os.environ.setdefault("BOT_TOKEN", "TEST")
+
+from bot import menu_keys
+
+
+@pytest.mark.asyncio
+async def test_menu_keys_shows_expiration():
+    message = SimpleNamespace(from_user=SimpleNamespace(id=1), chat=SimpleNamespace(id=2))
+    exp = 123
+    date_str = time.strftime("%d.%m.%Y", time.localtime(exp))
+    with patch("bot.get_active_key", new=AsyncMock(return_value=("url", exp, False))), \
+         patch("bot.send_temporary", new=AsyncMock()) as send_mock, \
+         patch("bot.time.time", return_value=0):
+        await menu_keys(message)
+    send_mock.assert_awaited()
+    text = send_mock.await_args.args[2]
+    assert "url" in text
+    assert date_str in text
+


### PR DESCRIPTION
## Summary
- display expiration date when viewing active keys
- add regression test for active keys menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687117a2f22c83208118e5bd53c99889