### PR TITLE
Rename Outline key with user id

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -88,7 +88,13 @@ def outline_manager() -> Manager:
 
 async def create_outline_key(label: str | None = None) -> dict:
     manager = outline_manager()
-    return await asyncio.to_thread(manager.new, label)
+    key = await asyncio.to_thread(manager.new, label)
+    if label and "id" in key:
+        try:
+            await asyncio.to_thread(manager.rename, key["id"], label)
+        except Exception as exc:
+            logging.error("Failed to rename Outline key: %s", exc)
+    return key
 
 
 def schedule_key_deletion(

--- a/tests/test_menu_keys.py
+++ b/tests/test_menu_keys.py
@@ -17,13 +17,15 @@ async def test_menu_keys_shows_expiration():
     message = SimpleNamespace(from_user=SimpleNamespace(id=1), chat=SimpleNamespace(id=2))
     exp = 123
     date_str = time.strftime("%d.%m.%Y", time.localtime(exp))
-    with patch("bot.get_active_key", new=AsyncMock(return_value=("url", exp, False))), \
-         patch("bot.send_temporary", new=AsyncMock()) as send_mock, \
-         patch("bot.time.time", return_value=0):
+    with patch(
+        "bot.get_active_key", new=AsyncMock(return_value=("url", exp, False))
+    ), patch("bot.send_temporary", new=AsyncMock()) as send_mock, patch(
+        "bot.time.time", return_value=0
+    ):
         await menu_keys(message)
-   assert len(send_mock.await_args_list) == 2
-    first_text = send_mock.await_args_list[0].args[2]
-    second_text = send_mock.await_args_list[1].args[2]
-    assert date_str in first_text
-    assert "url" == second_text
+        assert len(send_mock.await_args_list) == 2
+        first_text = send_mock.await_args_list[0].args[2]
+        second_text = send_mock.await_args_list[1].args[2]
+        assert date_str in first_text
+        assert "url" == second_text
 

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -19,10 +19,11 @@ async def test_create_outline_key_calls_manager():
         "bot.Manager"
     ) as manager_cls:
         manager = manager_cls.return_value
-        manager.new.return_value = {"accessUrl": "url"}
+        manager.new.return_value = {"accessUrl": "url", "id": 11}
         res = await create_outline_key(label="vpn_7")
         manager_cls.assert_called_with(
             apiurl="https://example.com/api", apicrt=""
         )
         manager.new.assert_called_with("vpn_7")
-        assert res == {"accessUrl": "url"}
+        manager.rename.assert_called_with(11, "vpn_7")
+        assert res == {"accessUrl": "url", "id": 11}


### PR DESCRIPTION
## Summary
- name Outline access keys after creation using telegram id
- update Outline tests
- fix indentation in `test_menu_keys`

## Testing
- `pip install -r requirements.txt -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68712207f1d88320a120093f23981109