### PR TITLE
Fix referral share link

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -451,7 +451,8 @@ async def menu_invite(message: types.Message):
         inline_keyboard=[
             [
                 InlineKeyboardButton(
-                    text="\U0001f4e3 Поделиться", switch_inline_query=link
+                    text="\U0001f4e3 Поделиться",
+                    url=f"https://t.me/share/url?url={link}",
                 )
             ],
             [

--- a/tests/test_referral.py
+++ b/tests/test_referral.py
@@ -48,7 +48,10 @@ async def test_menu_invite_generates_link():
     args, kwargs = message.answer.call_args
     assert "https://t.me/VPNos_bot?start=ref4" in args[0]
     kb = kwargs["reply_markup"]
-    assert kb.inline_keyboard[0][0].switch_inline_query == "https://t.me/VPNos_bot?start=ref4"
+    assert (
+        kb.inline_keyboard[0][0].url
+        == "https://t.me/share/url?url=https://t.me/VPNos_bot?start=ref4"
+    )
     assert kb.inline_keyboard[1][0].callback_data == "main_menu"
 
 


### PR DESCRIPTION
## Summary
- fix share button to use t.me/share link without bot name
- update referral tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687185284e048320b0e4ae87767f0feb