### PR TITLE
Fix admin commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -13,6 +13,7 @@ from aiogram.types import (
 from aiogram import F
 from outline_api import Manager
 import time
+from admin import router as admin_router
 from db import (
     init_db,
     add_key,
@@ -477,6 +478,7 @@ async def back_to_menu(message: types.Message):
 
 async def main() -> None:
     await init_db()
+    dp.include_router(admin_router)
     asyncio.create_task(notify_expirations_loop())
     await dp.start_polling(bot)
 


### PR DESCRIPTION
## Summary
- include admin router in the main bot so `/users` and `/userlist` commands are available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68718beea96c8320be0ec23c7b175e61