### PR TITLE
Notify trial users of expirations

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -170,7 +170,7 @@ async def notify_expirations_loop(interval: int = 60 * 60) -> None:
         async with get_connection() as conn:
             cursor = await conn.execute(
                 "SELECT user_id, expires_at FROM vpn_access "
-                "WHERE key_id IS NOT NULL AND expires_at IS NOT NULL AND is_trial=0"
+                "WHERE key_id IS NOT NULL AND expires_at IS NOT NULL"
             )
             rows = await cursor.fetchall()
         for user_id, expires_at in rows:

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,24 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bot import notify_expirations_loop
+
+@pytest.mark.asyncio
+async def test_notify_expirations_loop_selects_all_keys():
+    conn = AsyncMock()
+    conn.__aenter__.return_value = conn
+    conn.__aexit__.return_value = AsyncMock()
+    cursor = AsyncMock()
+    conn.execute.return_value = cursor
+    cursor.fetchall.return_value = []
+
+    with patch("bot.get_connection", return_value=conn), \
+         patch("bot.bot.send_message", new=AsyncMock()), \
+         patch("bot.asyncio.sleep", new=AsyncMock(side_effect=asyncio.CancelledError)):
+        with pytest.raises(asyncio.CancelledError):
+            await notify_expirations_loop(interval=0)
+
+    query = conn.execute.await_args.args[0].lower()
+    assert "is_trial" not in query


### PR DESCRIPTION
## Summary
- notify all active keys instead of only paid ones
- add test verifying query for expiration notifications

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68718d699cd88320b37a4d611be81453