### PR TITLE
Link to payment for 1‑month plan

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -435,6 +435,30 @@ async def menu_buy(message: types.Message):
     await message.answer(text, reply_markup=tariff_kb)
 
 
+@dp.message(F.text == "\U0001f7e1 1 мес — 199\u20bd")
+async def buy_one_month(message: types.Message):
+    """Send payment link for the 1 month subscription."""
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="\u27a1\ufe0f Оплатить",
+                    url="https://t.me/tribute/app?startapp=piiP",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="\U0001f4a0 Главное меню", callback_data="main_menu"
+                )
+            ],
+        ]
+    )
+    await message.answer(
+        "Для оплаты подписки на 1 месяц нажмите кнопку ниже:",
+        reply_markup=kb,
+    )
+
+
 @dp.message(F.text == "\U0001f381 Пригласить")
 async def menu_invite(message: types.Message):
     first_name = message.from_user.first_name or "друг"

--- a/tests/test_buy.py
+++ b/tests/test_buy.py
@@ -1,0 +1,20 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+os.environ.setdefault("BOT_TOKEN", "TEST")
+
+from bot import buy_one_month  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_buy_one_month_sends_link():
+    message = SimpleNamespace(answer=AsyncMock())
+    await buy_one_month(message)
+    args, kwargs = message.answer.call_args
+    kb = kwargs["reply_markup"]
+    assert kb.inline_keyboard[0][0].url == "https://t.me/tribute/app?startapp=piiP"


### PR DESCRIPTION
## Summary
- add a handler for the 1‑month tariff that returns a payment link
- test that the handler sends the correct payment link

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687243fc10148320b6ad226cc1ca6914