### PR TITLE
Implement reviews channel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ If you have an [Outline](https://getoutline.org/) VPN server, set the
 `OUTLINE_API_URL` environment variable to your server's API URL. The bot will
 create a new access key when you select "🔑 Мои активные ключи".
 
+Set the `REVIEWS_CHANNEL_URL` environment variable to the link of your Telegram
+channel with user reviews. When configured, the "🧑‍💬 Отзывы" button will show a
+link opening this channel.
+
 ## Persistent data on Railway
 
 To keep the SQLite database across restarts, create a Railway volume and mount

--- a/bot.py
+++ b/bot.py
@@ -44,6 +44,9 @@ OUTLINE_API_URL = os.getenv("OUTLINE_API_URL")
 
 DELETE_DELAY = int(os.getenv("DELETE_DELAY", "30"))
 
+# URL of the Telegram channel with user reviews
+REVIEWS_CHANNEL_URL = os.getenv("REVIEWS_CHANNEL_URL")
+
 # Number of days granted to a referrer for each invited user
 REFERRAL_BONUS_DAYS = 3
 
@@ -399,7 +402,16 @@ async def menu_keys(message: types.Message):
 
 @dp.message(F.text == "\U0001f9d1\u200d\U0001f4ac Отзывы")
 async def menu_reviews(message: types.Message):
-    await send_temporary(bot, message.chat.id, 'Раздел "Отзывы" пока в разработке')
+    """Show reviews channel link if configured."""
+    if REVIEWS_CHANNEL_URL:
+        kb = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [InlineKeyboardButton(text="\u27a1\ufe0f Открыть канал", url=REVIEWS_CHANNEL_URL)]
+            ]
+        )
+        await message.answer("Отзывы о VPN:", reply_markup=kb)
+    else:
+        await send_temporary(bot, message.chat.id, 'Раздел "Отзывы" пока в разработке')
 
 
 @dp.message(F.text == "\U0001f6d2 Купить VPN | \U0001f4c5 Продлить")

--- a/tests/test_reviews.py
+++ b/tests/test_reviews.py
@@ -1,0 +1,37 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+os.environ.setdefault("BOT_TOKEN", "TEST")
+
+from bot import menu_reviews  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_menu_reviews_with_url():
+    os.environ["REVIEWS_CHANNEL_URL"] = "https://t.me/test_channel"
+    with patch("bot.REVIEWS_CHANNEL_URL", "https://t.me/test_channel"), patch(
+        "bot.send_temporary", new=AsyncMock()
+    ):
+        message = SimpleNamespace(answer=AsyncMock())
+        await menu_reviews(message)
+        args, kwargs = message.answer.call_args
+        kb = kwargs["reply_markup"]
+        assert kb.inline_keyboard[0][0].url == "https://t.me/test_channel"
+
+
+@pytest.mark.asyncio
+async def test_menu_reviews_without_url():
+    if "REVIEWS_CHANNEL_URL" in os.environ:
+        del os.environ["REVIEWS_CHANNEL_URL"]
+    with patch("bot.REVIEWS_CHANNEL_URL", None), patch(
+        "bot.send_temporary", new=AsyncMock()
+    ) as send_mock:
+        message = SimpleNamespace(chat=SimpleNamespace(id=1))
+        await menu_reviews(message)
+        send_mock.assert_awaited()
+


### PR DESCRIPTION
## Summary
- add `REVIEWS_CHANNEL_URL` env variable and handler logic
- show reviews channel link when configured
- document new variable in README
- test reviews menu

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d2c4dc2c8320a1fbd36ae0418bf7