### PR TITLE
Update admin commands docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ After that administrators can use special commands:
 - `/userlist <page>` &mdash; display detailed information about users by page
   (20 entries per page).
 
+Users are recorded in the database when they send the `/start` command or
+when they receive a VPN key. The `/users` and `/userlist` commands list
+only these recorded users.
+
 Only users whose IDs are present in `ADMINS` can run these commands.
 
 ## Requirements


### PR DESCRIPTION
## Summary
- clarify when users are stored in the database
- specify that admin listing commands show only recorded users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872e09259508320ab707a4c85a2120b